### PR TITLE
Fix inconsistent indentation in setuptype.bash

### DIFF
--- a/dotfiles/sh_functions.d/setuptype.bash
+++ b/dotfiles/sh_functions.d/setuptype.bash
@@ -24,22 +24,22 @@ setuptype() {
             echo "linux-server"
             return
         elif [[ $(dmesg | grep "Booting paravirtualized kernel") ]]; then
-	    echo "linux-virtual"
-	    return
+            echo "linux-virtual"
+            return
         elif [[ $(uname -n) == "pi" ]]; then
             echo "linux-rpi"
             export MALT_SETUPTYPE="Raspberry Pi"
             return
         fi
 
-	case $(hostname) in
-	    duro*)
-		echo "linux-server"
-		;;
-	    *)
-		echo "linux"
-		;;
-	esac
+        case $(hostname) in
+            duro*)
+                echo "linux-server"
+                ;;
+            *)
+                echo "linux"
+                ;;
+        esac
         return
      fi
 


### PR DESCRIPTION
## Summary
- Standardize indentation to 4 spaces throughout setuptype.bash
- Fix mix of tabs and spaces that caused readability issues
- Improve code maintainability and consistency

## Test plan
- [x] Verify function still works correctly
- [x] Check indentation is consistent throughout file

🤖 Generated with [Claude Code](https://claude.ai/code)